### PR TITLE
Remove upper version limit

### DIFF
--- a/directlfq/__init__.py
+++ b/directlfq/__init__.py
@@ -13,7 +13,7 @@ __keywords__ = [
     "software",
     "AlphaPept ecosystem",
 ]
-__python_version__ = ">=3.8,<3.10"
+__python_version__ = ">=3.8"
 __classifiers__ = [
     # "Development Status :: 1 - Planning",
     # "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
I would like to use directLFQ with more recent python versions. 
Based on my local testing and knowledge of the used libraries, there should be no issue.