### PR TITLE
add new release and publish workflows

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,26 @@
+# Create a draft release and build and upload all installers to it.
+name: Create Draft Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_to_release:
+        description: 'Enter commit hash to release (example: ef4037cb571f99cb4919b520fde7174972aae473)'
+        type: string
+        required: true
+      tag_to_release:
+        description: 'Enter tag to release (example: v1.5.5)'
+        type: string
+        required: true
+
+jobs:
+  create-release:
+    uses: MannLabs/alphashared/.github/workflows/create_release.yml@v1
+    secrets: inherit
+    permissions:
+      contents: write
+    with:
+      package_name: directlfq
+      build_nodejs_ui: false
+      commit_to_release: ${{ inputs.commit_to_release }}
+      tag_to_release: ${{ inputs.tag_to_release }}

--- a/.github/workflows/publish_on_pypi.yml
+++ b/.github/workflows/publish_on_pypi.yml
@@ -1,0 +1,22 @@
+# Publish and test releases on Test-PyPI and PyPI.
+name: Publish on PyPi
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_to_release:
+        description: 'Enter tag to release (example: v1.5.5). A tag with the same name must exist in the repository.'
+        type: string
+        required: true
+
+jobs:
+  publish_on_pypi:
+    uses: MannLabs/alphashared/.github/workflows/publish_on_pypi.yml@v1
+    with:
+      # see the documentation of the workflow for more information on the parameters
+      package_name: directlfq
+      tag_to_release: ${{ inputs.tag_to_release }}
+      use_pyproject_toml: false
+    secrets:
+      test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Add new release workflows.
Needs to go directly to `master` in order to be usable for testing the adapted code in a branch.