### PR TITLE
Add release template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
+changelog:
+  exclude:
+#    labels:
+#      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Other Changes / unlabeled
+      labels:
+        - "*"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -24,3 +24,4 @@ jobs:
       build_nodejs_ui: false
       commit_to_release: ${{ inputs.commit_to_release }}
       tag_to_release: ${{ inputs.tag_to_release }}
+      python_version: "3.8"

--- a/README.md
+++ b/README.md
@@ -204,8 +204,19 @@ Ammar, C., Schessner, J.P., Willems, S., Michaelis, A.C., and Mann, M. (2023). A
 ---
 ## How to contribute
 
-If you like this software, you can give us a [star](https://github.com/MannLabs/directlfq/stargazers) to boost our visibility! All direct contributions are also welcome. Feel free to post a new [issue](https://github.com/MannLabs/directlfq/issues) or clone the repository and create a [pull request](https://github.com/MannLabs/directlfq/pulls) with a new branch. For an even more interactive participation, check out the [discussions](https://github.com/MannLabs/directlfq/discussions) and the [the Contributors License Agreement](misc/CLA.md).
+If you like this software, you can give us a [star](https://github.com/MannLabs/directlfq/stargazers) to boost our visibility! All direct contributions are also welcome. 
+Feel free to post a new [issue](https://github.com/MannLabs/directlfq/issues) or clone the repository and create a [pull request](https://github.com/MannLabs/directlfq/pulls) with a new branch. 
+For an even more interactive participation, check out the [discussions](https://github.com/MannLabs/directlfq/discussions) and the [the Contributors License Agreement](misc/CLA.md).
 
+### Tagging of changes
+In order to have release notes automatically generated, changes need to be tagged with labels.
+The following labels are used (should be safe-explanatory):
+`breaking-change`, `bug`, `enhancement`.
+
+### Release a new version
+This package uses a shared release process defined in the
+[alphashared](https://github.com/MannLabs/alphashared) repository. Please see the instructions
+[there](https://github.com/MannLabs/alphashared/blob/reusable-release-workflow/.github/workflows/README.md#release-a-new-version)
 
 ---
 


### PR DESCRIPTION
Adding a release template and docu on it.

Note: I also added the docs for the new release process already, otherwise I'd run into merge conflicts with https://github.com/MannLabs/directlfq/pull/42