### PR TITLE
Step 1: vectorize get_list_with_protein_value_for_each_sample

### DIFF
--- a/directlfq/protein_intensity_estimation.py
+++ b/directlfq/protein_intensity_estimation.py
@@ -232,7 +232,9 @@ def get_list_with_protein_value_for_each_sample(
     arr = normalized_peptide_profile_df.to_numpy()
     nonan_counts = np.sum(~np.isnan(arr), axis=0)
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=RuntimeWarning)  # all-NaN columns -> NaN
+        warnings.simplefilter(
+            "ignore", category=RuntimeWarning
+        )  # all-NaN columns -> NaN
         intens_vec = np.nanmedian(arr, axis=0)
     intens_vec[nonan_counts < min_nonan] = np.nan
     return intens_vec

--- a/directlfq/protein_intensity_estimation.py
+++ b/directlfq/protein_intensity_estimation.py
@@ -227,8 +227,23 @@ def get_protein_profile_from_shifted_peptides(
 
 
 def get_list_with_protein_value_for_each_sample(
-    normalized_peptide_profile_df, min_nonan
-):
+    normalized_peptide_profile_df: pd.DataFrame, min_nonan: int
+) -> np.ndarray:
+    """Collapse a protein's peptide profiles into one value per sample.
+
+    For each sample (column), the protein value is the median across its peptide
+    ion values, ignoring NaNs. A sample whose number of finite peptide values is
+    below ``min_nonan`` is set to NaN.
+
+    Args:
+        normalized_peptide_profile_df: Peptide ions (rows) by samples (columns)
+            of normalized log-space intensities.
+        min_nonan: Minimum number of finite peptide values a sample must have to
+            receive a protein value.
+
+    Returns:
+        One protein value per sample, in the column order of the input.
+    """
     arr = normalized_peptide_profile_df.to_numpy()
     nonan_counts = np.sum(~np.isnan(arr), axis=0)
     with warnings.catch_warnings():

--- a/directlfq/protein_intensity_estimation.py
+++ b/directlfq/protein_intensity_estimation.py
@@ -25,6 +25,7 @@ import directlfq.normalization as lfqnorm
 import multiprocess
 import itertools
 import logging
+import warnings
 import directlfq.config as config
 
 config.setup_logging()
@@ -228,14 +229,12 @@ def get_protein_profile_from_shifted_peptides(
 def get_list_with_protein_value_for_each_sample(
     normalized_peptide_profile_df, min_nonan
 ):
-    intens_vec = []
-    for sample in normalized_peptide_profile_df.columns:
-        reps = normalized_peptide_profile_df.loc[:, sample].to_numpy()
-        nonan_elems = sum(~np.isnan(reps))
-        if nonan_elems >= min_nonan:
-            intens_vec.append(np.nanmedian(reps))
-        else:
-            intens_vec.append(np.nan)
+    arr = normalized_peptide_profile_df.to_numpy()
+    nonan_counts = np.sum(~np.isnan(arr), axis=0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)  # all-NaN columns -> NaN
+        intens_vec = np.nanmedian(arr, axis=0)
+    intens_vec[nonan_counts < min_nonan] = np.nan
     return intens_vec
 
 

--- a/tests/pytest/test_protein_intensity_estimation.py
+++ b/tests/pytest/test_protein_intensity_estimation.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 
 import directlfq.protein_intensity_estimation as lfq_protint
 import directlfq.test_utils as lfq_testutils
@@ -157,3 +158,68 @@ def test_nameswitch_indices_are_recovered_correctly():
 
     assert (array[start_indices[3] : start_indices[4]] == "d").all()
     assert len(array[start_indices[3] : start_indices[4]]) == 1
+
+
+# ============================================================================
+# get_list_with_protein_value_for_each_sample (optimization step 1)
+# ============================================================================
+# Contract locked in before vectorizing the per-sample Series loop into a single
+# numpy column-nanmedian pass: for each sample (column) return the nanmedian of
+# its ion values when at least ``min_nonan`` are finite, otherwise NaN.
+
+
+def _profile_df(rows):
+    """Build an ion-profile DataFrame (rows = ions, columns = samples)."""
+    return pd.DataFrame(rows)
+
+
+def test_protein_value_per_sample_returns_column_nanmedians_when_all_finite():
+    # given - three samples, all values finite
+    df = _profile_df([[1.0, 4.0, 10.0], [3.0, 6.0, 20.0], [5.0, 8.0, 30.0]])
+
+    # when
+    result = lfq_protint.get_list_with_protein_value_for_each_sample(df, min_nonan=1)
+
+    # then - per-column median, in column order
+    assert np.array_equal(np.asarray(result), np.array([3.0, 6.0, 20.0]))
+
+
+def test_protein_value_per_sample_skips_nans_in_median():
+    # given - a column with an even number of finite values (median is averaged)
+    df = _profile_df([[4.0], [np.nan], [6.0]])
+
+    # when
+    result = lfq_protint.get_list_with_protein_value_for_each_sample(df, min_nonan=1)
+
+    # then - nanmedian over {4, 6}
+    assert np.array_equal(np.asarray(result), np.array([5.0]))
+
+
+def test_protein_value_per_sample_all_nan_column_is_nan():
+    # given - one all-NaN sample alongside a finite one
+    df = _profile_df([[1.0, np.nan], [3.0, np.nan]])
+
+    # when
+    result = lfq_protint.get_list_with_protein_value_for_each_sample(df, min_nonan=1)
+
+    # then - finite column keeps its median, all-NaN column -> NaN
+    assert np.array_equal(np.asarray(result), np.array([2.0, np.nan]), equal_nan=True)
+
+
+@pytest.mark.parametrize(
+    "min_nonan,expected",
+    [
+        (1, [3.0, 5.0, np.nan]),
+        (2, [3.0, 5.0, np.nan]),
+        (3, [3.0, np.nan, np.nan]),
+    ],
+)
+def test_protein_value_per_sample_applies_min_nonan_threshold(min_nonan, expected):
+    # given - sample finite-counts of 3, 2 and 0 respectively
+    df = _profile_df([[1.0, 4.0, np.nan], [3.0, np.nan, np.nan], [5.0, 6.0, np.nan]])
+
+    # when
+    result = lfq_protint.get_list_with_protein_value_for_each_sample(df, min_nonan)
+
+    # then - a column is NaN-ed out only when its finite count < min_nonan
+    assert np.array_equal(np.asarray(result), np.array(expected), equal_nan=True)


### PR DESCRIPTION
Replaces the per-sample pandas `Series` loop (24 Series built per protein) with a single numpy column-wise `nanmedian` + `min_nonan` mask.

**Estimated speedup:** estimate stage 137.6 s → 123.9 s (~1.1×), single-core HYE benchmark.

Bit-identical protein + ion output (`max_abs_diff=0`); unit + full pytest suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)