### PR TITLE
Step 2: vectorize NormalizationManager._determine_sorted_rows

### DIFF
--- a/directlfq/normalization.py
+++ b/directlfq/normalization.py
@@ -398,15 +398,6 @@ class NormalizationManager:
             linear_shifted_dataframe
         )
 
-    @staticmethod
-    @njit
-    def _get_num_nas_in_row(row):
-        sum = 0
-        isnans = np.isnan(row)
-        for is_nan in isnans:
-            sum += is_nan
-        return sum
-
 
 class NormalizationManagerSamples(NormalizationManager):
     def __init__(self, complete_dataframe, num_samples_quadratic):

--- a/directlfq/normalization.py
+++ b/directlfq/normalization.py
@@ -366,12 +366,9 @@ class NormalizationManager:
 
     def _determine_sorted_rows(self):
         rows = self.complete_dataframe.index
-        self._rows_sorted_by_number_valid_values = sorted(
-            rows,
-            key=lambda idx: self._get_num_nas_in_row(
-                self.complete_dataframe.loc[idx, :].to_numpy()
-            ),
-        )
+        nan_counts = np.isnan(self.complete_dataframe.to_numpy()).sum(axis=1)
+        order = np.argsort(nan_counts, kind="stable")
+        self._rows_sorted_by_number_valid_values = [rows[i] for i in order]
 
     def _normalize_quadratic_selection(self):
         quadratic_subset_dataframe = self.complete_dataframe.loc[

--- a/directlfq/normalization.py
+++ b/directlfq/normalization.py
@@ -364,7 +364,12 @@ class NormalizationManager:
             if x not in self._quadratic_subset_rows
         ]
 
-    def _determine_sorted_rows(self):
+    def _determine_sorted_rows(self) -> None:
+        """Order the dataframe's index labels by ascending number of NaNs per row.
+
+        Stores the result in ``self._rows_sorted_by_number_valid_values``. Ties are
+        broken stably, so rows with equal NaN counts keep their original order.
+        """
         rows = self.complete_dataframe.index
         nan_counts = np.isnan(self.complete_dataframe.to_numpy()).sum(axis=1)
         order = np.argsort(nan_counts, kind="stable")

--- a/directlfq/protein_intensity_estimation.py
+++ b/directlfq/protein_intensity_estimation.py
@@ -241,7 +241,6 @@ def get_list_with_protein_value_for_each_sample(
 
 
 import pandas as pd
-from numba import njit
 
 
 class ProtvalCutter:
@@ -278,15 +277,6 @@ class ProtvalCutter:
                 ),  # Then by sum of intensities (descending)
             ),
         )
-
-    @staticmethod
-    @njit
-    def _get_num_nas_in_row(row):
-        sum = 0
-        isnans = np.isnan(row)
-        for is_nan in isnans:
-            sum += is_nan
-        return sum
 
     def get_dataframe(self):
         if self._dataframe_too_long:

--- a/tests/pytest/test_normalization.py
+++ b/tests/pytest/test_normalization.py
@@ -155,6 +155,63 @@ def test_that_profiles_with_noise_are_close():
     )
 
 
+# ============================================================================
+# NormalizationManager._determine_sorted_rows (optimization step 2)
+# ============================================================================
+# Contract locked in before replacing the per-row .loc sort key with a numpy
+# nan-count + stable argsort: index labels ordered by ascending NaN-count, with
+# ties broken stably (original order preserved for equal counts).
+
+
+def _norm_manager_with_rows(rows):
+    """NormalizationManager over rows (ions) with a (protein, ion) MultiIndex."""
+    index = pd.MultiIndex.from_tuples(
+        [("P", f"ion{i}") for i in range(len(rows))], names=["protein", "ion"]
+    )
+    df = pd.DataFrame(rows, index=index)
+    return lfq_norm.NormalizationManager(df, num_samples_quadratic=100)
+
+
+def test_determine_sorted_rows_orders_by_ascending_nan_count_stably():
+    # given - rows with nan-counts 0, 2, 1, 3, 1 (the two 1s are a tie)
+    rows = [
+        [1.0, 2.0, 3.0],
+        [1.0, np.nan, np.nan],
+        [1.0, 2.0, np.nan],
+        [np.nan, np.nan, np.nan],
+        [4.0, 5.0, np.nan],
+    ]
+    mgr = _norm_manager_with_rows(rows)
+
+    # when
+    mgr._determine_sorted_rows()
+
+    # then - ascending nan-count; ion2 before ion4 (stable tie-break)
+    assert mgr._rows_sorted_by_number_valid_values == [
+        ("P", "ion0"),
+        ("P", "ion2"),
+        ("P", "ion4"),
+        ("P", "ion1"),
+        ("P", "ion3"),
+    ]
+
+
+def test_determine_sorted_rows_preserves_original_order_when_no_nans():
+    # given - all rows fully finite (all keys equal -> stable order is identity)
+    rows = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+    mgr = _norm_manager_with_rows(rows)
+
+    # when
+    mgr._determine_sorted_rows()
+
+    # then
+    assert mgr._rows_sorted_by_number_valid_values == [
+        ("P", "ion0"),
+        ("P", "ion1"),
+        ("P", "ion2"),
+    ]
+
+
 def _calc_distance(samples_1, samples_2):
     distrib = lfq_norm.get_fcdistrib(samples_1, samples_2)
     is_all_nan = np.all(np.isnan(distrib))


### PR DESCRIPTION
Replaces the per-row `.loc` MultiIndex lookup inside `sorted()`'s key with a numpy nan-count + stable `argsort` (reproduces Python `sorted()`'s tie-breaking).

**Estimated speedup:** estimate stage 123.9 s → 116.9 s (~1.06×), single-core HYE benchmark.

Bit-identical protein + ion output (`max_abs_diff=0`); suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)