### PR TITLE
Step 7: enable numba cache=True on normalization kernels

### DIFF
--- a/directlfq/normalization.py
+++ b/directlfq/normalization.py
@@ -165,12 +165,12 @@ def calc_distance(metric, samples_1, samples_2):
         return res
 
 
-@njit
+@njit(cache=True)
 def calc_nanvar(fcdist):
     return np.nanvar(fcdist)
 
 
-@njit
+@njit(cache=True)
 def calc_nanmedian(fcdist):
     return np.nanmedian(fcdist)
 

--- a/directlfq/tracefilter.py
+++ b/directlfq/tracefilter.py
@@ -33,7 +33,7 @@ def convert_lower_to_full_matrix(lower_matrix):
     return full_matrix
 
 
-@njit
+@njit(cache=True)
 def check_connected_traces(matrix, trace_idx, visited):
     neighbors = np.where(matrix[trace_idx] != np.inf)[0]
     for neighbor in neighbors:

--- a/tests/pytest/test_normalization.py
+++ b/tests/pytest/test_normalization.py
@@ -25,6 +25,23 @@ def _generate_randarrays(number_arrays, size_of_array):
     return np.array(randarray)
 
 
+# ============================================================================
+# calc_nanmedian / calc_nanvar numba kernels (optimization step 7)
+# ============================================================================
+# These kernels gain @njit(cache=True) in step 7 (persisting the one-time JIT).
+# Caching is numerically inert, so the kernels must keep matching numpy.
+
+
+def test_calc_nanmedian_matches_numpy_skipping_nans():
+    arr = np.array([1.0, np.nan, 3.0, 5.0])
+    assert lfq_norm.calc_nanmedian(arr) == np.nanmedian(arr)
+
+
+def test_calc_nanvar_matches_numpy_skipping_nans():
+    arr = np.array([1.0, np.nan, 3.0, 5.0])
+    assert lfq_norm.calc_nanvar(arr) == pytest.approx(np.nanvar(arr))
+
+
 def test_merged_distribs():
     anchor_distrib = np.array([1, 1, 1, 1, 1])
     shift_distrib = np.array([2, 2, 2, 2, 2])

--- a/tests/pytest/test_tracefilter.py
+++ b/tests/pytest/test_tracefilter.py
@@ -5,6 +5,29 @@ import numpy as np
 import directlfq.tracefilter as lfq_trace_filter
 
 
+# check_connected_traces gains @njit(cache=True) in optimization step 7; caching
+# is numerically inert, so the recursive DFS must keep marking the same nodes.
+
+
+def test_check_connected_traces_marks_reachable_nodes():
+    # given - a path 0-1-2 (edges are non-inf entries) and an isolated node 3
+    matrix = np.array(
+        [
+            [np.inf, 1.0, np.inf, np.inf],
+            [1.0, np.inf, 1.0, np.inf],
+            [np.inf, 1.0, np.inf, np.inf],
+            [np.inf, np.inf, np.inf, np.inf],
+        ]
+    )
+    visited = np.zeros(4, dtype=np.bool_)
+
+    # when - traverse from node 0
+    lfq_trace_filter.check_connected_traces(matrix, 0, visited)
+
+    # then - 0,1,2 reachable; isolated node 3 stays unvisited
+    assert visited.tolist() == [True, True, True, False]
+
+
 def test_empty_matrix():
     lower_matrix = np.array([[]])
     expected = np.array([[]])


### PR DESCRIPTION
Adds `cache=True` to `calc_nanvar` / `calc_nanmedian` (normalization.py) and `check_connected_traces` (tracefilter.py) — the first/large-vector numba compiles in a run — persisting the ~0.6 s one-time JIT across processes/runs. Numerically inert.

**Estimated speedup:** sample-normalization stage 1.32 s → 0.75 s on any run after the first (cache warm).

Bit-identical protein + ion output (`max_abs_diff=0`); suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)