### PR TITLE
Opt/step5 attempt2

### DIFF
--- a/benchmark_/STEP5_REDO_PLAN.md
+++ b/benchmark_/STEP5_REDO_PLAN.md
@@ -1,0 +1,326 @@
+# Step 5 redo — eliminate per-protein DataFrames (numpy slices on the hot path)
+
+This document distills PR #88 into its **final, intended design** and lays out a
+clean, **step-by-step reviewable** implementation: a small number of commits that
+are each logically complete, individually green (suite passes), and individually
+bit-exact against the reference.
+
+It supersedes the step-5 section of `IMPLEMENTATION_PLAN.md`, which describes an
+earlier design that PR #88 reversed during review (it duplicated the normalization
+math into `protein_intensity_estimation.py` and kept `ProtvalCutter`). This plan
+bakes the final decisions in from the first commit, so the history reads as a
+clean build instead of a build-then-unbuild.
+
+> Steps 1–4, 6, 7 of the optimization series are unchanged — see
+> `IMPLEMENTATION_PLAN.md`. Step 5 sits on top of step 4
+> (`opt/step4-numpy-normalize-quadratic-linear`).
+
+---
+
+## 1. Why this step exists
+
+After step 4 the per-protein numerical math is already numpy, but the **work items
+crossing the multiprocessing boundary are still per-protein pandas DataFrames**:
+
+- `get_normed_dfs` / `get_subdf` build ~14,240 `MultiIndex` sub-DataFrames
+  **serially** (~2.5 s just to construct them).
+- Each is **pickled to a worker and back** (~69 MB total); the equivalent numpy is
+  ~10× cheaper to serialize. This is why multi-core scaling stalled at ~4× on 8 cores.
+
+**Goal:** replace the per-protein pandas interface end to end with numpy. The
+producer ships contiguous array slices, the worker computes on arrays and returns
+arrays, and the assembly functions read those arrays.
+
+**Measured gain:** estimate stage 16.2 s → **9.6 s** single-core (~1.7×), and 8-core
+estimate ~10.5 s → **~2.4 s** (scaling restored; serial sub-DataFrame build 2.5 s → ~0.01 s).
+
+---
+
+## 2. Key design decisions (the distilled "what")
+
+These are the decisions the final PR converged on. They are the contract this redo
+must hit; the commit plan in §5 is just how to land them reviewably.
+
+1. **Contiguous numpy slices, not DataFrames, are the unit of work.**
+   `normed_df` is sorted by `(protein, ion)`, so each protein is a contiguous row
+   block. `find_nameswitch_indices(protein_names)` gives the block boundaries; the
+   producer slices `normed_df.to_numpy()` per protein. No per-protein DataFrame is
+   ever built.
+
+2. **The work item is a 6-tuple, the worker result a 4-tuple.**
+   - Work item: `(idx, protein_name, ion_names, peptide_values, num_samples_quadratic, min_nonan)`
+     — positional match to `calculate_peptide_and_protein_intensities`.
+   - Result: `(protein_profile, protein_name, ion_names, shifted_values)`.
+     `peptide_values`/`shifted_values` have **rows = ions, columns = samples**.
+     `protein_profile` is `None` when every sample collapses to NaN.
+
+3. **One shared normalization implementation, living in `normalization.py`.**
+   The per-protein normalization is a module-level function
+   `normalize_protein_ion_values(peptide_values, num_samples_quadratic)`.
+   `NormalizationManagerProtein._normalize_quadratic_and_linear` *delegates* to it,
+   and the hot path calls it directly. There is **no duplicated copy** in
+   `protein_intensity_estimation.py`.
+   - *Why this matters:* step 4 added a numpy override on the class; an early
+     version of step 5 copied that logic into the hot path, leaving two divergent
+     copies of order-sensitive float math. A single source removes that risk and is
+     the reason `NormalizationManagerProtein` (still used by `visualizations.py`)
+     stays correct.
+
+4. **`normalize_protein_ion_values` reproduces *both* dispatch branches.**
+   The base `NormalizationManager._run_normalization` dispatches on ion count:
+   `n <= k` → quadratic-only (`_normalize_complete_input_quadratic`, rows in
+   **original order**); `n > k` → quadratic+linear. The hot path bypasses that
+   dispatch, so the standalone function must contain **both** branches. The
+   class only ever reaches it on the `n > k` branch, so the class stays byte-identical.
+   - The `n <= k` branch must **not** be folded into the sorted split — the
+     quadratic-only path feeds rows to `get_normfacts` in original order, and
+     `get_normfacts`' pair selection is order-sensitive.
+
+5. **`ProtvalCutter` (class + numba `_get_num_nas_in_row`) is replaced and removed.**
+   A numpy helper `_cut_peptide_values(peptide_values, ion_names, maximum=100)`
+   does the same "keep ≤100 ions, sort by NaN-count asc then summed-intensity desc"
+   reduction. `get_subdf` / `get_normed_dfs` are also removed. `OrphanIonRemover` /
+   `OrphanIonsForDeletionSelector` / `IonCheckedForOrphan` (dead, only listed in
+   `__all__`) go too.
+
+6. **Single-sample guard is kept.** When `peptide_values.shape[1] < 2` (one sample),
+   skip normalization and keep values as-is. Otherwise `get_normfacts` NaNs out
+   every single-intensity ion row and the protein drops out of the output entirely.
+
+---
+
+## 3. The two bit-exactness gotchas (the correctness crux)
+
+Float summation/median are **not associative**, so changing reduction *order* or
+*memory layout* flips the last bit and propagates to a ~1e-6 table difference. Both
+traps below were found by bisecting an `exact=False` verdict and must be reproduced
+exactly by the numpy code.
+
+**Gotcha 1 — `np.nansum` memory order.** The old `summed_pepint =
+np.nansum(2 ** peptide_intensity_df)` summed a homogeneous float DataFrame, which
+pandas stores **column-major (Fortran order)**. `np.nansum(2**c_contiguous_slice)`
+sums row-major → differs by ~1 ULP, which flows through
+`log2(summed_pepint / …)` into the **protein** table (the ion table never uses
+`summed_pepint`). **Fix:** `np.nansum(np.asfortranarray(2 ** peptide_values))`.
+Affects only proteins with >100 ions (12 on HYE), so unit data is too small to
+catch it — the **optbench reference check is the real guard**.
+
+**Gotcha 2 — `np.lexsort` must reproduce `sorted()`'s tie-break.** `ProtvalCutter`
+sorted with `sorted(idxs, key=lambda i: (nan_count(i), -nansum(i)))` (stable).
+`_cut_peptide_values` must produce the **same order**, not just the same set, or the
+quadratic-subset selection *and* the `summed_pepint` order change. Use
+`np.lexsort((neg_summed, nan_counts))` — last key is primary, lexsort is stable, so
+full ties keep original (ion-name) order, matching `sorted()`.
+
+---
+
+## 4. Verification protocol (run after every commit)
+
+1. **`python optbench.py`** → must print `VERDICT identical=True` with
+   `max_abs_diff == 0` for both the protein and ion tables (sorted by id columns,
+   compared with `equal_nan=True`). The baseline reference is captured once on the
+   pre-step-5 code via `python optbench.py save`.
+2. **pytest** (excluding seaborn-dependent viz/benchmark modules) — stays green.
+3. Run from a neutral working directory, not the repo root (the `directlfq/` package
+   dir would shadow the installed package).
+
+Every commit below is expected to pass both 1 and 2.
+
+---
+
+## 5. Implementation plan — 5 reviewable commits
+
+Each commit is logically complete, leaves the suite green, and stays bit-exact.
+The ordering follows *"make the change easy, then make the easy change"*: a
+behavior-preserving refactor (commit 1) first reshapes the code so the later numpy
+flip is a small, obvious diff, then the helpers are proven against the code they
+replace, then the interface flips, then the dead code is deleted.
+
+> **Why the upfront refactor (commit 1) matters.** PR #88 changed two independent
+> things in one commit: (a) how protein/ion **metadata reaches the assembly
+> functions** — they re-derived `protein_name`/`ion_names` from the result
+> DataFrame's `MultiIndex` — and (b) the **compute substrate** (DataFrame → numpy).
+> Bundled, the diff is large and the assembly functions appear to change "because of
+> numpy" when they really change because of metadata plumbing. Commit 1 does (a)
+> alone, *while still on DataFrames*, so the assembly functions reach their final
+> shape early and the numpy flip (commit 4) doesn't touch them at all.
+
+### Commit 1 — Preparatory refactor: explicit metadata tuple (protein_intensity_estimation.py)
+
+**What.** Behavior-preserving, still 100% DataFrame-based. Two changes:
+
+1. **Rename** `get_input_specification_tuplelist_idx__df__num_samples_quadratic__min_nonan`
+   → `get_protein_workitems` (pure rename; body unchanged, still builds DataFrames
+   via `get_normed_dfs`/`get_subdf`).
+2. **Make the worker return metadata explicitly.** Today
+   `calculate_peptide_and_protein_intensities` returns `(protein_profile,
+   shifted_df)`, and the assembly functions dig `protein_name`/`ion_names` out of
+   `shifted_df.index`. Change the worker to extract them **after** the `ProtvalCutter`
+   cut and return the final 4-tuple shape `(protein_profile, protein_name, ion_names,
+   shifted_values)`, where `shifted_values = shifted_df.to_numpy()`. Update both
+   assembly functions to read the tuple fields directly (`protein_name`,
+   `ion_names.tolist()`, `np.concatenate(ion_vals)` over the arrays).
+
+Everything numeric stays on DataFrames: the worker still uses `ProtvalCutter`,
+`NormalizationManagerProtein`, and `np.nansum(2 ** peptide_intensity_df)` (no Fortran
+fix yet — that arrives with the array switch in commit 4).
+
+**Why it's safe.** No reduction order or memory layout changes; `shifted_df.to_numpy()`
+carries the identical numbers the assembly already converted via `.to_numpy()`.
+Bit-exact, suite green.
+
+**Payoff.** After this commit the assembly functions are in their **final** form, so
+commit 4 (the numpy flip) shrinks to: producer body, worker compute substrate, and
+the two profile helpers — and the reviewer never has to disentangle metadata plumbing
+from the numpy migration.
+
+**Tests.** Update tests that unpack the worker result / drive the assembly functions
+to the 4-tuple shape (this is the only test churn for the new tuple — commit 4 won't
+revisit it).
+
+**Verify.** optbench identical + pytest green.
+
+---
+
+### Commit 2 — Extract the shared `normalize_protein_ion_values` (normalization.py)
+
+**What.** Lift the numpy body of `NormalizationManagerProtein._normalize_quadratic_and_linear`
+(from step 4) into a module-level function
+`normalize_protein_ion_values(peptide_values, num_samples_quadratic)`. The function
+contains **both** dispatch branches (decision §2.4); the class method becomes a thin
+delegator:
+
+```python
+def _normalize_quadratic_and_linear(self) -> None:
+    df = self.complete_dataframe
+    arr = normalize_protein_ion_values(
+        df.to_numpy(dtype=float), self._num_samples_quadratic
+    )
+    self.complete_dataframe = pd.DataFrame(arr, index=df.index, columns=df.columns)
+```
+
+Add `normalize_protein_ion_values` to `__all__`. The input array is not mutated
+(`.copy()` inside).
+
+**Why this is safe.** The class only calls this method on the `n > k` branch, and
+that branch is the unchanged step-4 code, so `NormalizationManagerProtein` output is
+byte-for-byte identical. The `n <= k` branch is new code that only the (future) hot
+path exercises. This is decision §2.3 + §2.4 landed up front, so it never has to be
+"consolidated" later.
+
+**Tests.** Pin `normalize_protein_ion_values` against the **base-class `.loc`
+pipeline** it reimplements — drive a plain `NormalizationManager` with
+`normalization_function = normalize_ion_profiles` and call `_run_normalization()`,
+*not* the delegating subclass (otherwise the test is circular). Two cases:
+- quadratic+linear (`n=5 > k=3`, mixed NaNs);
+- quadratic-only (`n=3 <= k=5`; verifies the original-order branch).
+
+**Verify.** optbench identical (class unchanged) + pytest green.
+
+---
+
+### Commit 3 — Add `_cut_peptide_values`, proven against the live `ProtvalCutter` (protein_intensity_estimation.py)
+
+**What.** Add the numpy cutting helper (decision §2.5, Gotcha 2). Do **not** wire it
+into the worker yet — `ProtvalCutter` is still present and still used.
+
+```python
+def _cut_peptide_values(peptide_values, ion_names, maximum=100):
+    if peptide_values.shape[0] <= maximum:
+        return peptide_values, ion_names
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        neg_summed = -np.nansum(peptide_values, axis=1)
+    nan_counts = np.isnan(peptide_values).sum(axis=1)
+    order = np.lexsort((neg_summed, nan_counts))[:maximum]  # Gotcha 2
+    return peptide_values[order], ion_names[order]
+```
+
+**Why a separate commit.** This is the strangler pattern: introduce and *prove* the
+replacement beside the original, then switch (commit 4), then delete (commit 5).
+While both exist, the helper can be tested for **direct equivalence against the live
+`ProtvalCutter`** on real inputs — the strongest possible check, and one that
+disappears once the class is gone.
+
+**Tests.** Equivalence vs. `ProtvalCutter` on (a) a `>maximum` case including a full
+tie on both keys (asserts ion order, not just the set) and (b) a within-limit no-op.
+
+**Verify.** optbench identical (helper unwired) + pytest green.
+
+> Optional: commits 3 and 4 can be merged if a separate "unwired helper" commit is
+> unwanted. Keeping them split gives the reviewer a focused diff for the subtle
+> lexsort tie-break with a direct A/B test against the class it replaces.
+
+---
+
+### Commit 4 — Flip the hot path to numpy slices (protein_intensity_estimation.py)
+
+**What.** The irreducible interface change. Because the contract changes from
+DataFrame to numpy, **tests and implementation land in the same commit** (the new
+shape can't be verified against the pre-change code).
+
+- **Producer** — replace `get_input_specification_…` / `get_normed_dfs` / `get_subdf`
+  with one generator `get_protein_workitems(normed_df, num_samples_quadratic,
+  min_nonan)` yielding the 6-tuple over `find_nameswitch_indices` slices (decision
+  §2.1, §2.2).
+- **Worker** — `calculate_peptide_and_protein_intensities` takes the 6-tuple, returns
+  the 4-tuple; uses `_cut_peptide_values` (when `>1` ion),
+  `lfqnorm.normalize_protein_ion_values`, the single-sample guard (§2.6), and the
+  Fortran-order `summed_pepint` (Gotcha 1).
+- **Profile helpers** — `get_protein_profile_from_shifted_peptides` and
+  `get_list_with_protein_value_for_each_sample` take a numpy array (drop the
+  `df.to_numpy()` line).
+- **Assembly** — *unchanged.* They already read the 4-tuple and operate on arrays
+  after commit 1. This is the payoff of the upfront refactor.
+- **Pool wrappers** — `get_list_with_sequential_processing` /
+  `get_list_with_multiprocessing` only get their parameter renamed (generic
+  `map`/`starmap`, no logic change).
+
+`ProtvalCutter` / `get_subdf` / `get_normed_dfs` are now dead but **stay** this
+commit — removing them is commit 5, keeping this diff scoped to the interface flip.
+The commit-3 `_cut_peptide_values`-vs-`ProtvalCutter` tests still pass.
+
+**Tests.** Update the `get_list_with_protein_value_for_each_sample` tests to pass
+arrays. Add: single-sample values are kept (not NaN-ed) and the protein is retained.
+(The worker-returns-4-tuple and ion-df-from-tuples tests already exist from commit 1.)
+
+**Verify.** optbench `identical=True` (this is where Gotcha 1 actually bites —
+unit data is too small) + pytest green.
+
+---
+
+### Commit 5 — Remove dead code, de-circularize tests, update probes
+
+**What.**
+- Delete `ProtvalCutter` (and its `@njit _get_num_nas_in_row`, and the
+  now-unused `from numba import njit`), `get_subdf`, `get_normed_dfs`,
+  `OrphanIonRemover`, `OrphanIonsForDeletionSelector`, `IonCheckedForOrphan`.
+  Prune all of these from `__all__`; add `get_protein_workitems`.
+- **De-circularize the commit-3 tests:** the `ProtvalCutter` reference is gone, so
+  replace the equivalence assertions with **hardcoded expectations** (same inputs,
+  expected ion order/values written out).
+- **Benchmark probes:** move the old `ProtvalCutter` sort/cut into
+  `benchmark_/optbench.py` as `protvalcutter_reference_sorted_index` /
+  `protvalcutter_reference_cut`, and update `layoutprobe.py`, `orderprobe.py`,
+  `sumprobe.py` to call those (they currently reach into the deleted class).
+
+**Why last.** The deletions are only safe once nothing references the symbols
+(verified: no callers in `directlfq/` or `tests/` after commit 4; the only
+`NormalizationManagerProtein` consumer, `visualizations.py`, is untouched by step 5).
+
+**Verify.** optbench identical + pytest green.
+
+---
+
+## 6. Commit summary
+
+| # | file(s) | change | green & bit-exact |
+|---|---------|--------|:--:|
+| 1 | `protein_intensity_estimation.py` (+ test) | **prep refactor (DataFrame-based):** rename → `get_protein_workitems`; worker returns explicit `(profile, name, ion_names, shifted_values)`; assembly reads tuple fields | ✓ |
+| 2 | `normalization.py` (+ test_normalization) | extract module-level `normalize_protein_ion_values` (both branches); class delegates | ✓ |
+| 3 | `protein_intensity_estimation.py` (+ test) | add `_cut_peptide_values`, proven vs. live `ProtvalCutter` (unwired) | ✓ |
+| 4 | `protein_intensity_estimation.py` (+ test) | flip hot path: numpy producer/worker + array profile helpers (assembly untouched), Gotcha 1 + single-sample guard | ✓ |
+| 5 | `protein_intensity_estimation.py`, `optbench.py`, probes (+ test) | delete `ProtvalCutter`/`get_subdf`/`get_normed_dfs`/Orphan*, prune `__all__`, de-circularize tests, point probes at optbench reference | ✓ |
+
+After commit 5: `optbench.py` prints `VERDICT identical=True`, pytest is green, and a
+1/2/4/8-core `bench_dlfq.py` run confirms the restored multi-core scaling.

--- a/benchmark_/bench_estimate.py
+++ b/benchmark_/bench_estimate.py
@@ -1,7 +1,7 @@
 """Break the 'estimate' stage into its serial vs parallel sub-steps.
 
 estimate_protein_intensities does, in order:
-  1. build per-protein sub-DataFrames (get_normed_dfs)   -> SERIAL
+  1. build per-protein work items (get_protein_workitems) -> SERIAL
   2. map calculate_peptide_and_protein_intensities       -> PARALLEL (pool) / serial
   3. assemble protein dataframe                           -> SERIAL
   4. compile ion dataframe                                -> SERIAL
@@ -42,13 +42,9 @@ def main() -> None:
         df, num_samples_quadratic=50, selected_proteins_file=None
     ).complete_dataframe
 
-    # 1. build per-protein sub-DataFrames (this is what gets pickled to workers)
+    # 1. build per-protein work items (this is what gets pickled to workers)
     t = time.perf_counter()
-    spec = list(
-        lfqprot.get_input_specification_tuplelist_idx__df__num_samples_quadratic__min_nonan(
-            normed_df, 10, 1
-        )
-    )
+    spec = list(lfqprot.get_protein_workitems(normed_df, 10, 1))
     t_build = time.perf_counter() - t
     n = len(spec)
 

--- a/benchmark_/jit_probe.py
+++ b/benchmark_/jit_probe.py
@@ -20,11 +20,7 @@ df = lfqutils.remove_allnan_rows_input_df(df)
 normed = lfqnorm.NormalizationManagerSamplesOnSelectedProteins(
     df, num_samples_quadratic=50, selected_proteins_file=None
 ).complete_dataframe
-spec = list(
-    lfqprot.get_input_specification_tuplelist_idx__df__num_samples_quadratic__min_nonan(
-        normed, 10, 1
-    )
-)
+spec = list(lfqprot.get_protein_workitems(normed, 10, 1))
 # process just first 50 proteins single-core: time dominated by one-time JIT compile
 t = time.perf_counter()
 lfqprot.get_list_with_sequential_processing(iter(spec[:50]))

--- a/benchmark_/layoutprobe.py
+++ b/benchmark_/layoutprobe.py
@@ -11,7 +11,7 @@ diff_ids = [ids[i].split("\t")[0] for i in np.where(d.max(axis=1) > 1e-12)[0]]
 ok = {"C": 0, "F": 0, "T": 0, "col": 0}
 for p in diff_ids:
     sub = normed[pn == p]
-    cut_df = lfqprot.ProtvalCutter(sub.copy(), maximum_df_length=100).get_dataframe()
+    cut_df = optbench.protvalcutter_reference_cut(sub.copy(), 100)
     old = np.nansum(2**cut_df)
     vals = sub.to_numpy()
     ino = sub.index.get_level_values(1).to_numpy()

--- a/benchmark_/optbench.py
+++ b/benchmark_/optbench.py
@@ -49,6 +49,36 @@ def prep():
     ).complete_dataframe
 
 
+def protvalcutter_reference_sorted_index(protvals_df):
+    """Reference: the original ProtvalCutter index sort, kept for the probes to compare
+    the numpy _cut_peptide_values against now that ProtvalCutter is removed.
+
+    Primary key: number of NaNs (ascending); secondary: summed intensity (descending).
+    """
+    idxs = protvals_df.index
+    return sorted(
+        idxs,
+        key=lambda idx: (
+            sum(
+                np.isnan(protvals_df.loc[idx].to_numpy())
+            ),  # First by number of NaNs (ascending)
+            -np.nansum(
+                protvals_df.loc[idx].to_numpy()
+            ),  # Then by sum of intensities (descending)
+        ),
+    )
+
+
+def protvalcutter_reference_cut(protvals_df, maximum_df_length=100):
+    """Reference: the original ProtvalCutter cut -- keep the top maximum_df_length rows."""
+    if len(protvals_df.index) <= maximum_df_length:
+        return protvals_df
+    shortened_index = protvalcutter_reference_sorted_index(protvals_df)[
+        :maximum_df_length
+    ]
+    return protvals_df.loc[shortened_index]
+
+
 def df_to_arrays(df):
     """Stable representation: id strings (from protein/ion id cols) + sorted float matrix."""
     df = df.reset_index()

--- a/benchmark_/orderprobe.py
+++ b/benchmark_/orderprobe.py
@@ -12,9 +12,8 @@ target = [p for p, c in counts.items() if c == 102][0]
 sub = normed[pn == target]
 vals = sub.to_numpy()
 ion_names = sub.index.get_level_values(1).to_numpy()
-# ProtvalCutter order
-pc = lfqprot.ProtvalCutter(sub.copy(), maximum_df_length=100)
-pc_idx = pc._sorted_idx[:100]
+# ProtvalCutter reference order
+pc_idx = optbench.protvalcutter_reference_sorted_index(sub.copy())[:100]
 pc_ions = [t[1] for t in pc_idx]
 # my lexsort order
 with np.errstate(all="ignore"):

--- a/benchmark_/pickle_probe.py
+++ b/benchmark_/pickle_probe.py
@@ -1,5 +1,4 @@
 import time, pickle
-import numpy as np
 import directlfq.config as config
 import directlfq.utils as lfqutils
 import directlfq.normalization as lfqnorm
@@ -21,20 +20,14 @@ df = lfqutils.remove_allnan_rows_input_df(df)
 normed = lfqnorm.NormalizationManagerSamplesOnSelectedProteins(
     df, num_samples_quadratic=50, selected_proteins_file=None
 ).complete_dataframe
-dfs = lfqprot.get_normed_dfs(normed)
-print("n sub-dataframes:", len(dfs))
-# pickle the list of per-protein DataFrames (what Pool ships to workers)
+workitems = list(lfqprot.get_protein_workitems(normed, 10, 1))
+print("n work items:", len(workitems))
+# pickle the list of per-protein numpy work items (what Pool ships to workers)
 t = time.perf_counter()
-blob = pickle.dumps(dfs, protocol=pickle.HIGHEST_PROTOCOL)
-t_df = time.perf_counter() - t
-print(f"DataFrames: pickle {t_df:.2f}s  size {len(blob) / 1e6:.1f} MB")
+blob = pickle.dumps(workitems, protocol=pickle.HIGHEST_PROTOCOL)
+t_wi = time.perf_counter() - t
+print(f"work items: pickle {t_wi:.2f}s  size {len(blob) / 1e6:.1f} MB")
 t = time.perf_counter()
 _ = pickle.loads(blob)
-t_dfl = time.perf_counter() - t
-print(f"DataFrames: unpickle {t_dfl:.2f}s")
-# equivalent as raw numpy arrays (values only)
-arrs = [d.to_numpy() for d in dfs]
-t = time.perf_counter()
-blob2 = pickle.dumps(arrs, protocol=pickle.HIGHEST_PROTOCOL)
-t_np = time.perf_counter() - t
-print(f"numpy arrays: pickle {t_np:.2f}s  size {len(blob2) / 1e6:.1f} MB")
+t_wil = time.perf_counter() - t
+print(f"work items: unpickle {t_wil:.2f}s")

--- a/benchmark_/prof.py
+++ b/benchmark_/prof.py
@@ -4,11 +4,7 @@ import directlfq.normalization as lfqnorm, directlfq.protein_intensity_estimatio
 import optbench
 
 normed = optbench.prep()
-spec = list(
-    lfqprot.get_input_specification_tuplelist_idx__df__num_samples_quadratic__min_nonan(
-        normed, 10, 1
-    )
-)[:2500]
+spec = list(lfqprot.get_protein_workitems(normed, 10, 1))[:2500]
 pr = cProfile.Profile()
 pr.enable()
 lfqprot.get_list_with_sequential_processing(iter(spec))

--- a/benchmark_/sumprobe.py
+++ b/benchmark_/sumprobe.py
@@ -13,8 +13,8 @@ diff_ids = [ids[i].split("\t")[0] for i in np.where(d.max(axis=1) > 1e-12)[0]]
 print("checking", len(diff_ids), "differing proteins")
 for p in diff_ids[:4]:
     sub = normed[pn == p]
-    # OLD path: ProtvalCutter df -> nansum(2**df)
-    cut_df = lfqprot.ProtvalCutter(sub.copy(), maximum_df_length=100).get_dataframe()
+    # OLD path: ProtvalCutter reference df -> nansum(2**df)
+    cut_df = optbench.protvalcutter_reference_cut(sub.copy(), 100)
     old_sum = np.nansum(2**cut_df)
     # NEW path: array cut -> nansum(2**arr)
     vals = sub.to_numpy()

--- a/directlfq/normalization.py
+++ b/directlfq/normalization.py
@@ -15,6 +15,7 @@ __all__ = [
     "merge_distribs",
     "normalize_dataframe_between_samples",
     "normalize_ion_profiles",
+    "normalize_protein_ion_values",
     "drop_nas_if_possible",
     "calculate_fraction_with_no_NAs",
     "NormalizationManager",
@@ -302,6 +303,58 @@ def normalize_ion_profiles(protein_profile_df):
     return df_normed
 
 
+def normalize_protein_ion_values(peptide_values, num_samples_quadratic):
+    """Normalize one protein's ion rows (rows = ions, columns = samples) and return a new array.
+
+    Reproduces the dispatch in ``NormalizationManager._run_normalization`` so the hot
+    path can bypass the class and its label-based MultiIndex round-trips:
+
+    - ``n_ions <= num_samples_quadratic``: every row is normalized together with the
+      quadratic pairwise-shift procedure, in original (ion-name) order.
+    - ``n_ions > num_samples_quadratic``: the ``num_samples_quadratic`` rows with the
+      fewest NaNs are normalized quadratically; the remaining rows are each shifted onto
+      the column-median of those normalized rows.
+
+    The input array is not mutated.
+    """
+    arr = peptide_values.astype(float, copy=True)
+    k = num_samples_quadratic
+
+    # cf. NormalizationManager._normalize_complete_input_quadratic (normalize_ion_profiles):
+    # the quadratic-only path must keep rows in original order -- get_normfacts' pair
+    # selection is order-sensitive, so this branch must not be folded into the sorted split.
+    if arr.shape[0] <= k:
+        sample2shift = get_normfacts(arr)  # mutates single-intensity rows -> NaN
+        return apply_sampleshifts(arr, sample2shift)
+
+    # cf. _determine_subset_rows(): positional k-fewest-NaN quadratic split, linear in original order
+    nan_counts = np.isnan(arr).sum(axis=1)
+    order = np.argsort(nan_counts, kind="stable")
+    q_pos = order[:k]
+    linear_mask = np.ones(arr.shape[0], dtype=bool)
+    linear_mask[q_pos] = False
+    lin_pos = np.flatnonzero(linear_mask)
+
+    # cf. _normalize_quadratic_selection()
+    q_vals = arr[q_pos].copy()
+    sample2shift = get_normfacts(q_vals)  # mutates single-intensity rows -> NaN
+    q_normed = apply_sampleshifts(q_vals, sample2shift)
+    arr[q_pos] = q_normed
+
+    with warnings.catch_warnings():
+        warnings.simplefilter(
+            "ignore", category=RuntimeWarning
+        )  # all-NaN slices -> NaN
+        # cf. _create_reference_sample()
+        reference = np.nanmedian(q_normed, axis=0)
+        # cf. _shift_remaining_dataframe_to_reference_sample()
+        if lin_pos.size:
+            shifts = np.nanmedian(reference - arr[lin_pos], axis=1)
+            arr[lin_pos] = arr[lin_pos] + shifts[:, None]
+
+    return arr
+
+
 def drop_nas_if_possible(df):
     df_nonans = df.dropna(axis=1)
     fraction_nonans = calculate_fraction_with_no_NAs(df, df_nonans)
@@ -505,44 +558,16 @@ class NormalizationManagerProtein(NormalizationManager):
         self._run_normalization()
 
     def _normalize_quadratic_and_linear(self) -> None:
-        """Normalize ion rows in two tiers and write the result back to ``complete_dataframe``.
+        """Delegate the two-tier ion normalization to the shared numpy implementation.
 
-        The ``num_samples_quadratic`` rows with the fewest NaNs are normalized with the
-        quadratic pairwise-shift procedure; every remaining row is shifted onto the median
-        profile of those normalized rows.
-
-        Numpy mirror of the base class's four-step ``.loc``-based pipeline, dropping the
-        label-based MultiIndex round-trips that dominate the estimate stage.
+        The base class only dispatches here on the ``n_ions > num_samples_quadratic``
+        branch, which ``normalize_protein_ion_values`` reproduces exactly; the same
+        function backs the numpy hot path in ``protein_intensity_estimation``.
         """
         df = self.complete_dataframe
-        arr = df.to_numpy(dtype=float, copy=True)  # copy as arr is mutated in-place
-        k = self._num_samples_quadratic
-
-        # cf. _determine_subset_rows(): positional k-fewest-NaN quadratic split, linear in original order
-        nan_counts = np.isnan(arr).sum(axis=1)
-        order = np.argsort(nan_counts, kind="stable")
-        q_pos = order[:k]
-        linear_mask = np.ones(arr.shape[0], dtype=bool)
-        linear_mask[q_pos] = False
-        lin_pos = np.flatnonzero(linear_mask)
-
-        # cf. _normalize_quadratic_selection()
-        q_vals = arr[q_pos].copy()
-        sample2shift = get_normfacts(q_vals)  # mutates single-intensity rows -> NaN
-        q_normed = apply_sampleshifts(q_vals, sample2shift)
-        arr[q_pos] = q_normed
-
-        with warnings.catch_warnings():
-            warnings.simplefilter(
-                "ignore", category=RuntimeWarning
-            )  # all-NaN slices -> NaN
-            # cf. _create_reference_sample()
-            reference = np.nanmedian(q_normed, axis=0)
-            # cf. _shift_remaining_dataframe_to_reference_sample()
-            if lin_pos.size:
-                shifts = np.nanmedian(reference - arr[lin_pos], axis=1)
-                arr[lin_pos] = arr[lin_pos] + shifts[:, None]
-
+        arr = normalize_protein_ion_values(
+            df.to_numpy(dtype=float), self._num_samples_quadratic
+        )
         self.complete_dataframe = pd.DataFrame(arr, index=df.index, columns=df.columns)
 
 

--- a/directlfq/protein_intensity_estimation.py
+++ b/directlfq/protein_intensity_estimation.py
@@ -167,7 +167,9 @@ def calculate_peptide_and_protein_intensities(
     summed_pepint = np.nansum(np.asfortranarray(2**peptide_values))
 
     if peptide_values.shape[1] < 2:
-        shifted_values = peptide_values  # single sample: skip normalization, keep values as-is
+        shifted_values = (
+            peptide_values  # single sample: skip normalization, keep values as-is
+        )
     else:
         shifted_values = lfqnorm.normalize_protein_ion_values(
             peptide_values, num_samples_quadratic

--- a/directlfq/protein_intensity_estimation.py
+++ b/directlfq/protein_intensity_estimation.py
@@ -23,7 +23,6 @@ import pandas as pd
 import numpy as np
 import directlfq.normalization as lfqnorm
 import multiprocess
-import itertools
 import logging
 import warnings
 import directlfq.config as config
@@ -74,34 +73,44 @@ def estimate_protein_intensities(
 def get_list_of_tuple_w_protein_profiles_and_shifted_peptides(
     normed_df, num_samples_quadratic, min_nonan, num_cores
 ):
-    input_specification_tuplelist_idx__df__num_samples_quadratic__min_nonan = (
-        get_protein_workitems(normed_df, num_samples_quadratic, min_nonan)
+    protein_workitems = get_protein_workitems(
+        normed_df, num_samples_quadratic, min_nonan
     )
 
     if num_cores is not None and num_cores <= 1:
         list_of_tuple_w_protein_profiles_and_shifted_peptides = (
-            get_list_with_sequential_processing(
-                input_specification_tuplelist_idx__df__num_samples_quadratic__min_nonan
-            )
+            get_list_with_sequential_processing(protein_workitems)
         )
     else:
         list_of_tuple_w_protein_profiles_and_shifted_peptides = (
-            get_list_with_multiprocessing(
-                input_specification_tuplelist_idx__df__num_samples_quadratic__min_nonan,
-                num_cores,
-            )
+            get_list_with_multiprocessing(protein_workitems, num_cores)
         )
     return list_of_tuple_w_protein_profiles_and_shifted_peptides
 
 
 def get_protein_workitems(normed_df, num_samples_quadratic, min_nonan):
-    list_of_normed_dfs = get_normed_dfs(normed_df)
-    return zip(
-        range(len(list_of_normed_dfs)),
-        list_of_normed_dfs,
-        itertools.repeat(num_samples_quadratic),
-        itertools.repeat(min_nonan),
-    )
+    """Yield one work item per protein as contiguous numpy slices (no per-protein DataFrame).
+
+    ``normed_df`` is sorted by (protein, ion), so each protein is a contiguous row block.
+    Each item is the 6-tuple expected positionally by
+    ``calculate_peptide_and_protein_intensities``; ``peptide_values`` has rows = ions,
+    columns = samples.
+    """
+    protein_names = normed_df.index.get_level_values(0).to_numpy()
+    ion_names = normed_df.index.get_level_values(1).to_numpy()
+    normed_array = normed_df.to_numpy()
+    switch_indices = find_nameswitch_indices(protein_names)
+    for idx in range(len(switch_indices) - 1):
+        start = switch_indices[idx]
+        end = switch_indices[idx + 1]
+        yield (
+            idx,
+            protein_names[start],
+            ion_names[start:end],
+            normed_array[start:end],
+            num_samples_quadratic,
+            min_nonan,
+        )
 
 
 def get_normed_dfs(normed_df):
@@ -144,25 +153,21 @@ def get_subdf(
     return pd.DataFrame(sub_array, index=index_sub_array)
 
 
-def get_list_with_sequential_processing(
-    input_specification_tuplelist_idx__df__num_samples_quadratic__min_nonan,
-):
+def get_list_with_sequential_processing(protein_workitems):
     list_of_tuple_w_protein_profiles_and_shifted_peptides = list(
         map(
             lambda x: calculate_peptide_and_protein_intensities(*x),
-            input_specification_tuplelist_idx__df__num_samples_quadratic__min_nonan,
+            protein_workitems,
         )
     )
     return list_of_tuple_w_protein_profiles_and_shifted_peptides
 
 
-def get_list_with_multiprocessing(
-    input_specification_tuplelist_idx__df__num_samples_quadratic__min_nonan, num_cores
-):
+def get_list_with_multiprocessing(protein_workitems, num_cores):
     pool = get_configured_multiprocessing_pool(num_cores)
     list_of_tuple_w_protein_profiles_and_shifted_peptides = pool.starmap(
         calculate_peptide_and_protein_intensities,
-        input_specification_tuplelist_idx__df__num_samples_quadratic__min_nonan,
+        protein_workitems,
     )
     pool.close()
     return list_of_tuple_w_protein_profiles_and_shifted_peptides
@@ -180,42 +185,39 @@ def get_configured_multiprocessing_pool(num_cores):
 
 
 def calculate_peptide_and_protein_intensities(
-    idx, peptide_intensity_df, num_samples_quadratic, min_nonan
+    idx, protein_name, ion_names, peptide_values, num_samples_quadratic, min_nonan
 ):
-    if len(peptide_intensity_df.index) > 1:
-        peptide_intensity_df = ProtvalCutter(
-            peptide_intensity_df, maximum_df_length=100
-        ).get_dataframe()
+    if peptide_values.shape[0] > 1:
+        peptide_values, ion_names = _cut_peptide_values(
+            peptide_values, ion_names, maximum=100
+        )
 
     if config.LOG_PROCESSED_PROTEINS and (
         idx % config.LOG_PROCESSED_PROTEINS_INTERVAL == 0
     ):
         LOGGER.info(f"lfq-object {idx}")
-    summed_pepint = np.nansum(2**peptide_intensity_df)
+    # Fortran order matches the column-major sum of the former homogeneous DataFrame (Gotcha 1)
+    summed_pepint = np.nansum(np.asfortranarray(2**peptide_values))
 
-    if peptide_intensity_df.shape[1] < 2:
-        shifted_peptides = peptide_intensity_df
+    if peptide_values.shape[1] < 2:
+        shifted_values = peptide_values  # single sample: skip normalization, keep values as-is
     else:
-        shifted_peptides = lfqnorm.NormalizationManagerProtein(
-            peptide_intensity_df, num_samples_quadratic=num_samples_quadratic
-        ).complete_dataframe
+        shifted_values = lfqnorm.normalize_protein_ion_values(
+            peptide_values, num_samples_quadratic
+        )
 
     protein_profile = get_protein_profile_from_shifted_peptides(
-        shifted_peptides, summed_pepint, min_nonan
+        shifted_values, summed_pepint, min_nonan
     )
-
-    protein_name = shifted_peptides.index.get_level_values(0)[0]
-    ion_names = shifted_peptides.index.get_level_values(1).to_numpy()
-    shifted_values = shifted_peptides.to_numpy()
 
     return protein_profile, protein_name, ion_names, shifted_values
 
 
 def get_protein_profile_from_shifted_peptides(
-    normalized_peptide_profile_df, summed_pepints, min_nonan
+    normalized_peptide_profiles, summed_pepints, min_nonan
 ):
     intens_vec = get_list_with_protein_value_for_each_sample(
-        normalized_peptide_profile_df, min_nonan
+        normalized_peptide_profiles, min_nonan
     )
     intens_vec = np.array(intens_vec)
     summed_intensity = np.nansum(2**intens_vec)
@@ -227,14 +229,15 @@ def get_protein_profile_from_shifted_peptides(
 
 
 def get_list_with_protein_value_for_each_sample(
-    normalized_peptide_profile_df: pd.DataFrame, min_nonan: int
+    normalized_peptide_profiles: np.ndarray, min_nonan: int
 ) -> np.ndarray:
     """Collapse a protein's normalized peptide profiles into one value per sample.
 
     Each sample (column) is summarized by the nanmedian of its ion values. Samples
-    with fewer than ``min_nonan`` finite ions are set to NaN.
+    with fewer than ``min_nonan`` finite ions are set to NaN. Input rows are ions,
+    columns are samples.
     """
-    arr = normalized_peptide_profile_df.to_numpy()
+    arr = normalized_peptide_profiles
     nonan_counts = np.sum(~np.isnan(arr), axis=0)
     with warnings.catch_warnings():
         warnings.simplefilter(

--- a/directlfq/protein_intensity_estimation.py
+++ b/directlfq/protein_intensity_estimation.py
@@ -249,6 +249,24 @@ import pandas as pd
 from numba import njit
 
 
+def _cut_peptide_values(peptide_values, ion_names, maximum=100):
+    """Reduce a protein to its ``maximum`` most informative ions (rows = ions).
+
+    Keeps ions sorted by NaN count ascending, then summed intensity descending --
+    the numpy equivalent of ``ProtvalCutter``. Reproduces ``ProtvalCutter``'s stable
+    ``sorted()`` tie-break: ions tied on both keys keep their original (ion-name) order.
+    """
+    if peptide_values.shape[0] <= maximum:
+        return peptide_values, ion_names
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)  # all-NaN rows -> NaN
+        neg_summed = -np.nansum(peptide_values, axis=1)
+    nan_counts = np.isnan(peptide_values).sum(axis=1)
+    # last key is primary and lexsort is stable -> full ties keep original order (Gotcha 2)
+    order = np.lexsort((neg_summed, nan_counts))[:maximum]
+    return peptide_values[order], ion_names[order]
+
+
 class ProtvalCutter:
     def __init__(self, protvals_df, maximum_df_length=100):
         self._protvals_df = protvals_df

--- a/directlfq/protein_intensity_estimation.py
+++ b/directlfq/protein_intensity_estimation.py
@@ -4,7 +4,7 @@ __all__ = [
     "get_list_with_sequential_processing",
     "get_list_with_multiprocessing",
     "get_configured_multiprocessing_pool",
-    "get_input_specification_tuplelist_idx__df__num_samples_quadratic__min_nonan",
+    "get_protein_workitems",
     "get_normed_dfs",
     "get_ion_intensity_dataframe_from_list_of_shifted_peptides",
     "add_protein_names_to_ion_ints",
@@ -75,9 +75,7 @@ def get_list_of_tuple_w_protein_profiles_and_shifted_peptides(
     normed_df, num_samples_quadratic, min_nonan, num_cores
 ):
     input_specification_tuplelist_idx__df__num_samples_quadratic__min_nonan = (
-        get_input_specification_tuplelist_idx__df__num_samples_quadratic__min_nonan(
-            normed_df, num_samples_quadratic, min_nonan
-        )
+        get_protein_workitems(normed_df, num_samples_quadratic, min_nonan)
     )
 
     if num_cores is not None and num_cores <= 1:
@@ -96,9 +94,7 @@ def get_list_of_tuple_w_protein_profiles_and_shifted_peptides(
     return list_of_tuple_w_protein_profiles_and_shifted_peptides
 
 
-def get_input_specification_tuplelist_idx__df__num_samples_quadratic__min_nonan(
-    normed_df, num_samples_quadratic, min_nonan
-):
+def get_protein_workitems(normed_df, num_samples_quadratic, min_nonan):
     list_of_normed_dfs = get_normed_dfs(normed_df)
     return zip(
         range(len(list_of_normed_dfs)),
@@ -208,7 +204,11 @@ def calculate_peptide_and_protein_intensities(
         shifted_peptides, summed_pepint, min_nonan
     )
 
-    return protein_profile, shifted_peptides
+    protein_name = shifted_peptides.index.get_level_values(0)[0]
+    ion_names = shifted_peptides.index.get_level_values(1).to_numpy()
+    shifted_values = shifted_peptides.to_numpy()
+
+    return protein_profile, protein_name, ion_names, shifted_values
 
 
 def get_protein_profile_from_shifted_peptides(
@@ -311,11 +311,12 @@ def get_ion_intensity_dataframe_from_list_of_shifted_peptides(
     ion_vals = []
     protein_names = []
     for idx in range(len(list_of_tuple_w_protein_profiles_and_shifted_peptides)):
-        ion_df = list_of_tuple_w_protein_profiles_and_shifted_peptides[idx][1]
-        protein_name = ion_df.index.get_level_values(0)[0]
-        ion_names += ion_df.index.get_level_values(1).tolist()
-        ion_vals.append(ion_df.to_numpy())
-        protein_names.extend([protein_name] * len(ion_df.index))
+        _, protein_name, ion_names_arr, shifted_values = (
+            list_of_tuple_w_protein_profiles_and_shifted_peptides[idx]
+        )
+        ion_names += ion_names_arr.tolist()
+        ion_vals.append(shifted_values)
+        protein_names.extend([protein_name] * len(ion_names_arr))
     merged_ions = 2 ** np.concatenate(ion_vals)
     merged_ions = np.nan_to_num(merged_ions)
     ion_df = pd.DataFrame(merged_ions)
@@ -349,10 +350,7 @@ def get_protein_dataframe_from_list_of_protein_profiles(
     list_of_protein_profiles = [
         x[0] for x in list_of_tuple_w_protein_profiles_and_shifted_peptides
     ]
-    allprots = [
-        x[1].index.get_level_values(0)[0]
-        for x in list_of_tuple_w_protein_profiles_and_shifted_peptides
-    ]
+    allprots = [x[1] for x in list_of_tuple_w_protein_profiles_and_shifted_peptides]
 
     for idx in range(len(allprots)):
         if list_of_protein_profiles[idx] is None:

--- a/directlfq/protein_intensity_estimation.py
+++ b/directlfq/protein_intensity_estimation.py
@@ -5,7 +5,6 @@ __all__ = [
     "get_list_with_multiprocessing",
     "get_configured_multiprocessing_pool",
     "get_protein_workitems",
-    "get_normed_dfs",
     "get_ion_intensity_dataframe_from_list_of_shifted_peptides",
     "add_protein_names_to_ion_ints",
     "add_protein_name_to_ion_df",
@@ -13,10 +12,6 @@ __all__ = [
     "calculate_peptide_and_protein_intensities",
     "get_protein_profile_from_shifted_peptides",
     "get_list_with_protein_value_for_each_sample",
-    "ProtvalCutter",
-    "OrphanIonRemover",
-    "OrphanIonsForDeletionSelector",
-    "IonCheckedForOrphan",
 ]
 
 import pandas as pd
@@ -113,21 +108,6 @@ def get_protein_workitems(normed_df, num_samples_quadratic, min_nonan):
         )
 
 
-def get_normed_dfs(normed_df):
-    protein_names = normed_df.index.get_level_values(0).to_numpy()
-    ion_names = normed_df.index.get_level_values(1).to_numpy()
-    normed_array = normed_df.to_numpy()
-    indices_of_proteinname_switch = find_nameswitch_indices(protein_names)
-    results_list = [
-        get_subdf(
-            normed_array, indices_of_proteinname_switch, idx, protein_names, ion_names
-        )
-        for idx in range(len(indices_of_proteinname_switch) - 1)
-    ]
-
-    return results_list
-
-
 def find_nameswitch_indices(arr):
     change_indices = np.where(arr[:-1] != arr[1:])[0] + 1
 
@@ -138,19 +118,6 @@ def find_nameswitch_indices(arr):
     start_indices = np.append(start_indices, len(arr))
 
     return start_indices
-
-
-def get_subdf(
-    normed_array, indices_of_proteinname_switch, idx, protein_names, ion_names
-):
-    start_switch = indices_of_proteinname_switch[idx]
-    end_switch = indices_of_proteinname_switch[idx + 1]
-    sub_array = normed_array[start_switch:end_switch]
-    index_sub_array = pd.MultiIndex.from_arrays(
-        [protein_names[start_switch:end_switch], ion_names[start_switch:end_switch]],
-        names=[config.PROTEIN_ID, config.QUANT_ID],
-    )
-    return pd.DataFrame(sub_array, index=index_sub_array)
 
 
 def get_list_with_sequential_processing(protein_workitems):
@@ -248,10 +215,6 @@ def get_list_with_protein_value_for_each_sample(
     return intens_vec
 
 
-import pandas as pd
-from numba import njit
-
-
 def _cut_peptide_values(peptide_values, ion_names, maximum=100):
     """Reduce a protein to its ``maximum`` most informative ions (rows = ions).
 
@@ -268,61 +231,6 @@ def _cut_peptide_values(peptide_values, ion_names, maximum=100):
     # last key is primary and lexsort is stable -> full ties keep original order (Gotcha 2)
     order = np.lexsort((neg_summed, nan_counts))[:maximum]
     return peptide_values[order], ion_names[order]
-
-
-class ProtvalCutter:
-    def __init__(self, protvals_df, maximum_df_length=100):
-        self._protvals_df = protvals_df
-        self._maximum_df_length = maximum_df_length
-        self._dataframe_too_long = None
-        self._sorted_idx = None
-        self._check_if_df_too_long_and_sort_index_if_so()
-
-    def _check_if_df_too_long_and_sort_index_if_so(self):
-        self._dataframe_too_long = (
-            len(self._protvals_df.index) > self._maximum_df_length
-        )
-        if self._dataframe_too_long:
-            self._determine_nansorted_df_index()
-
-    def _determine_nansorted_df_index(self):
-        """Sorts the dataframe index primarily by number of NaN values (ascending) and secondarily by summed intensity (descending). Sorting by intensties in case multiple ions have identical missing value counts. We expect initial sorting by ion name (which is done in the run_lfq module) to be deterministic.
-
-        The sorting prioritizes:
-        1. Rows with fewer NaN values come first
-        2. For rows with equal number of NaNs, higher intensity sums come first
-        """
-        idxs = self._protvals_df.index
-        self._sorted_idx = sorted(
-            idxs,
-            key=lambda idx: (
-                sum(
-                    np.isnan(self._protvals_df.loc[idx].to_numpy())
-                ),  # First by number of NaNs (ascending)
-                -np.nansum(
-                    self._protvals_df.loc[idx].to_numpy()
-                ),  # Then by sum of intensities (descending)
-            ),
-        )
-
-    @staticmethod
-    @njit
-    def _get_num_nas_in_row(row):
-        sum = 0
-        isnans = np.isnan(row)
-        for is_nan in isnans:
-            sum += is_nan
-        return sum
-
-    def get_dataframe(self):
-        if self._dataframe_too_long:
-            return self._get_shortened_dataframe()
-        else:
-            return self._protvals_df
-
-    def _get_shortened_dataframe(self):
-        shortened_index = self._sorted_idx[: self._maximum_df_length]
-        return self._protvals_df.loc[shortened_index]
 
 
 def get_ion_intensity_dataframe_from_list_of_shifted_peptides(

--- a/directlfq/visualizations.py
+++ b/directlfq/visualizations.py
@@ -98,7 +98,7 @@ class IonTraceCompararisonPlotter:
             self._protein_df_after_norm, ax=self.axis_normed
         )
         median_list = lfq_protint.get_list_with_protein_value_for_each_sample(
-            self._protein_df_after_norm, min_nonan=1
+            self._protein_df_after_norm.to_numpy(), min_nonan=1
         )
         visualizer.add_median_trace(median_list)
 

--- a/tests/pytest/test_normalization.py
+++ b/tests/pytest/test_normalization.py
@@ -294,6 +294,70 @@ def test_normalize_quadratic_and_linear_overlaps_noisefree_profiles():
 
 
 # ============================================================================
+# normalize_protein_ion_values (optimization step 5)
+# ============================================================================
+# Standalone numpy normalization shared by the class and the hot path. Pinned
+# against the base-class label-based .loc pipeline it reimplements -- driven via
+# a plain NormalizationManager (not the delegating subclass, which would be
+# circular). Covers both dispatch branches.
+
+
+def _base_class_normalized(df, num_samples_quadratic):
+    """Run the original base-class .loc pipeline (normalize_ion_profiles)."""
+    manager = lfq_norm.NormalizationManager(
+        df.copy(), num_samples_quadratic=num_samples_quadratic
+    )
+    manager.normalization_function = lfq_norm.normalize_ion_profiles
+    manager._run_normalization()
+    return manager.complete_dataframe.to_numpy()
+
+
+def test_normalize_protein_ion_values_matches_base_class_quadratic_and_linear():
+    # given - 5 ions x 4 samples, n=5 > k=3 -> quadratic+linear branch
+    df = _create_input_df_from_input_vals(
+        [
+            [1.0, 2.0, 3.0, 4.0],
+            [2.0, 3.0, 4.0, 5.0],
+            [10.0, np.nan, 12.0, 13.0],
+            [3.0, 4.0, 5.0, 6.0],
+            [np.nan, np.nan, 20.0, 21.0],
+        ]
+    )
+    expected = _base_class_normalized(df, num_samples_quadratic=3)
+
+    # when
+    result = lfq_norm.normalize_protein_ion_values(df.to_numpy(dtype=float), 3)
+
+    # then
+    assert np.array_equal(result, expected, equal_nan=True)
+
+
+def test_normalize_protein_ion_values_matches_base_class_quadratic_only():
+    # given - 3 ions x 4 samples, n=3 <= k=5 -> quadratic-only (original-order) branch
+    df = _create_input_df_from_input_vals(
+        [
+            [1.0, 2.0, 3.0, 4.0],
+            [10.0, np.nan, 12.0, 13.0],
+            [3.0, 4.0, 5.0, 6.0],
+        ]
+    )
+    expected = _base_class_normalized(df, num_samples_quadratic=5)
+
+    # when
+    result = lfq_norm.normalize_protein_ion_values(df.to_numpy(dtype=float), 5)
+
+    # then
+    assert np.array_equal(result, expected, equal_nan=True)
+
+
+def test_normalize_protein_ion_values_does_not_mutate_input():
+    arr = np.array([[1.0, 2.0, 3.0, 4.0], [2.0, 3.0, 4.0, 5.0]])
+    arr_before = arr.copy()
+    lfq_norm.normalize_protein_ion_values(arr, 5)
+    assert np.array_equal(arr, arr_before)
+
+
+# ============================================================================
 # SampleShifterLinear._shift_columns_to_reference_sample (optimization step 3)
 # ============================================================================
 # Contract locked in before replacing the per-row `iloc[r,:] +=` shift with a

--- a/tests/pytest/test_protein_intensity_estimation.py
+++ b/tests/pytest/test_protein_intensity_estimation.py
@@ -1,95 +1,56 @@
 """Tests for directlfq.protein_intensity_estimation, salvaged from nbdev_nbs/03_protein_intensity_estimation.ipynb."""
 
 import numpy as np
-import pandas as pd
 import pytest
 
 import directlfq.protein_intensity_estimation as lfq_protint
 import directlfq.test_utils as lfq_testutils
 
 
-def test_sorting_by_num_nans():
-    vals1 = np.array([9, np.nan, np.nan, np.nan])
-    vals2 = np.array([5, 6, np.nan, np.nan])
-    vals3 = np.array([1, 2, 3, np.nan])
-
-    df = pd.DataFrame([vals1, vals2, vals3], index=[["P", "P", "P"], ["A", "B", "C"]])
-    pcutter = lfq_protint.ProtvalCutter(df, maximum_df_length=2)
-    sorted_idx = pcutter._sorted_idx
-    df_sorted = df.loc[sorted_idx]
-
-    assert np.allclose(df_sorted.iloc[2].to_numpy(), vals1, equal_nan=True)
-    assert np.allclose(df_sorted.iloc[0].to_numpy(), vals3, equal_nan=True)
-
-
-def test_cutting_of_df():
-    vals1 = np.array([9, np.nan, np.nan, np.nan])
-    vals2 = np.array([5, 6, np.nan, np.nan])
-    vals3 = np.array([1, 2, 3, np.nan])
-
-    df = pd.DataFrame([vals1, vals2, vals3], index=[["A", "B", "C"]])
-    pcutter = lfq_protint.ProtvalCutter(df, maximum_df_length=2)
-    cut_df = pcutter.get_dataframe()
-    ion_idx = [x[0] for x in cut_df.index]
-    assert ion_idx == ["C", "B"]
-
-
 # ============================================================================
-# _cut_peptide_values (optimization step 5) -- proven against live ProtvalCutter
+# _cut_peptide_values (optimization step 5)
 # ============================================================================
-# Strangler check: the numpy cutter must produce the SAME ion order (not just the
-# same set) as ProtvalCutter, including the stable tie-break on full ties.
+# The numpy cutter keeps the <= maximum ions sorted by NaN count asc then summed
+# intensity desc, reproducing the former ProtvalCutter's stable sorted() tie-break
+# (ions tied on both keys keep their original order). Expectations are hardcoded.
 
 
-def _make_ion_df(rows, ion_names):
-    index = pd.MultiIndex.from_arrays([["P"] * len(ion_names), ion_names])
-    return pd.DataFrame(rows, index=index)
-
-
-def test_cut_peptide_values_matches_protvalcutter_order_with_full_tie():
+def test_cut_peptide_values_orders_by_nan_then_intensity_with_full_tie():
     # given - ion0 and ion1 are a full tie on both keys (nan=0, sum=6); the cut
     # keeps the top 3, so the tie-break (original order) is observable
-    ion_names = ["ion0", "ion1", "ion2", "ion3", "ion4"]
-    rows = [
-        [1.0, 2.0, 3.0],  # ion0: nan=0 sum=6
-        [1.0, 2.0, 3.0],  # ion1: nan=0 sum=6 (full tie with ion0)
-        [10.0, 20.0, 30.0],  # ion2: nan=0 sum=60
-        [5.0, np.nan, np.nan],  # ion3: nan=2 sum=5
-        [np.nan, np.nan, np.nan],  # ion4: nan=3 sum=0
-    ]
-    df = _make_ion_df(rows, ion_names)
-
-    cut_df = lfq_protint.ProtvalCutter(
-        df.copy(), maximum_df_length=3
-    ).get_dataframe()
-    pc_ions = [t[1] for t in cut_df.index]
+    ion_names = np.array(["ion0", "ion1", "ion2", "ion3", "ion4"])
+    peptide_values = np.array(
+        [
+            [1.0, 2.0, 3.0],  # ion0: nan=0 sum=6
+            [1.0, 2.0, 3.0],  # ion1: nan=0 sum=6 (full tie with ion0)
+            [10.0, 20.0, 30.0],  # ion2: nan=0 sum=60
+            [5.0, np.nan, np.nan],  # ion3: nan=2 sum=5
+            [np.nan, np.nan, np.nan],  # ion4: nan=3 sum=0
+        ]
+    )
 
     # when
     new_vals, new_ions = lfq_protint._cut_peptide_values(
-        df.to_numpy(), np.array(ion_names), maximum=3
+        peptide_values, ion_names, maximum=3
     )
 
-    # then - identical ion order and values
-    assert list(new_ions) == pc_ions
-    assert np.array_equal(new_vals, cut_df.to_numpy(), equal_nan=True)
+    # then - highest-sum first, then the full tie in original (ion-name) order
+    assert list(new_ions) == ["ion2", "ion0", "ion1"]
+    assert np.array_equal(
+        new_vals, np.array([[10.0, 20.0, 30.0], [1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
+    )
 
 
 def test_cut_peptide_values_is_noop_within_limit():
-    ion_names = ["ion0", "ion1", "ion2"]
-    rows = [[1.0, 2.0], [3.0, np.nan], [5.0, 6.0]]
-    df = _make_ion_df(rows, ion_names)
-
-    cut_df = lfq_protint.ProtvalCutter(
-        df.copy(), maximum_df_length=100
-    ).get_dataframe()
-    pc_ions = [t[1] for t in cut_df.index]
+    ion_names = np.array(["ion0", "ion1", "ion2"])
+    peptide_values = np.array([[1.0, 2.0], [3.0, np.nan], [5.0, 6.0]])
 
     new_vals, new_ions = lfq_protint._cut_peptide_values(
-        df.to_numpy(), np.array(ion_names), maximum=100
+        peptide_values, ion_names, maximum=100
     )
 
-    assert list(new_ions) == pc_ions == ion_names
-    assert np.array_equal(new_vals, cut_df.to_numpy(), equal_nan=True)
+    assert list(new_ions) == ["ion0", "ion1", "ion2"]
+    assert np.array_equal(new_vals, peptide_values, equal_nan=True)
 
 
 def test_that_protein_intensities_are_retained():

--- a/tests/pytest/test_protein_intensity_estimation.py
+++ b/tests/pytest/test_protein_intensity_estimation.py
@@ -226,14 +226,14 @@ def test_nameswitch_indices_are_recovered_correctly():
 # its ion values when at least ``min_nonan`` are finite, otherwise NaN.
 
 
-def _profile_df(rows):
-    """Build an ion-profile DataFrame (rows = ions, columns = samples)."""
-    return pd.DataFrame(rows)
+def _profile_array(rows):
+    """Build an ion-profile array (rows = ions, columns = samples)."""
+    return np.array(rows, dtype=float)
 
 
 def test_protein_value_per_sample_returns_column_nanmedians_when_all_finite():
     # given - three samples, all values finite
-    df = _profile_df([[1.0, 4.0, 10.0], [3.0, 6.0, 20.0], [5.0, 8.0, 30.0]])
+    df = _profile_array([[1.0, 4.0, 10.0], [3.0, 6.0, 20.0], [5.0, 8.0, 30.0]])
 
     # when
     result = lfq_protint.get_list_with_protein_value_for_each_sample(df, min_nonan=1)
@@ -244,7 +244,7 @@ def test_protein_value_per_sample_returns_column_nanmedians_when_all_finite():
 
 def test_protein_value_per_sample_skips_nans_in_median():
     # given - a column with an even number of finite values (median is averaged)
-    df = _profile_df([[4.0], [np.nan], [6.0]])
+    df = _profile_array([[4.0], [np.nan], [6.0]])
 
     # when
     result = lfq_protint.get_list_with_protein_value_for_each_sample(df, min_nonan=1)
@@ -255,7 +255,7 @@ def test_protein_value_per_sample_skips_nans_in_median():
 
 def test_protein_value_per_sample_all_nan_column_is_nan():
     # given - one all-NaN sample alongside a finite one
-    df = _profile_df([[1.0, np.nan], [3.0, np.nan]])
+    df = _profile_array([[1.0, np.nan], [3.0, np.nan]])
 
     # when
     result = lfq_protint.get_list_with_protein_value_for_each_sample(df, min_nonan=1)
@@ -274,10 +274,36 @@ def test_protein_value_per_sample_all_nan_column_is_nan():
 )
 def test_protein_value_per_sample_applies_min_nonan_threshold(min_nonan, expected):
     # given - sample finite-counts of 3, 2 and 0 respectively
-    df = _profile_df([[1.0, 4.0, np.nan], [3.0, np.nan, np.nan], [5.0, 6.0, np.nan]])
+    df = _profile_array([[1.0, 4.0, np.nan], [3.0, np.nan, np.nan], [5.0, 6.0, np.nan]])
 
     # when
     result = lfq_protint.get_list_with_protein_value_for_each_sample(df, min_nonan)
 
     # then - a column is NaN-ed out only when its finite count < min_nonan
     assert np.array_equal(np.asarray(result), np.array(expected), equal_nan=True)
+
+
+# ============================================================================
+# calculate_peptide_and_protein_intensities single-sample guard (step 5)
+# ============================================================================
+# With a single sample every ion has one intensity, so get_normfacts would NaN
+# every row and drop the protein. The guard skips normalization to keep values.
+
+
+def test_single_sample_values_are_kept_and_protein_retained():
+    # given - 3 ions, 1 sample
+    peptide_values = np.array([[5.0], [6.0], [7.0]])
+    ion_names = np.array(["ion0", "ion1", "ion2"])
+
+    # when
+    profile, name, ions, shifted = (
+        lfq_protint.calculate_peptide_and_protein_intensities(
+            0, "protA", ion_names, peptide_values, 10, 1
+        )
+    )
+
+    # then - values kept as-is (not normalized to NaN) and the protein is retained
+    assert np.array_equal(shifted, peptide_values, equal_nan=True)
+    assert profile is not None
+    assert name == "protA"
+    assert list(ions) == ["ion0", "ion1", "ion2"]

--- a/tests/pytest/test_protein_intensity_estimation.py
+++ b/tests/pytest/test_protein_intensity_estimation.py
@@ -34,6 +34,64 @@ def test_cutting_of_df():
     assert ion_idx == ["C", "B"]
 
 
+# ============================================================================
+# _cut_peptide_values (optimization step 5) -- proven against live ProtvalCutter
+# ============================================================================
+# Strangler check: the numpy cutter must produce the SAME ion order (not just the
+# same set) as ProtvalCutter, including the stable tie-break on full ties.
+
+
+def _make_ion_df(rows, ion_names):
+    index = pd.MultiIndex.from_arrays([["P"] * len(ion_names), ion_names])
+    return pd.DataFrame(rows, index=index)
+
+
+def test_cut_peptide_values_matches_protvalcutter_order_with_full_tie():
+    # given - ion0 and ion1 are a full tie on both keys (nan=0, sum=6); the cut
+    # keeps the top 3, so the tie-break (original order) is observable
+    ion_names = ["ion0", "ion1", "ion2", "ion3", "ion4"]
+    rows = [
+        [1.0, 2.0, 3.0],  # ion0: nan=0 sum=6
+        [1.0, 2.0, 3.0],  # ion1: nan=0 sum=6 (full tie with ion0)
+        [10.0, 20.0, 30.0],  # ion2: nan=0 sum=60
+        [5.0, np.nan, np.nan],  # ion3: nan=2 sum=5
+        [np.nan, np.nan, np.nan],  # ion4: nan=3 sum=0
+    ]
+    df = _make_ion_df(rows, ion_names)
+
+    cut_df = lfq_protint.ProtvalCutter(
+        df.copy(), maximum_df_length=3
+    ).get_dataframe()
+    pc_ions = [t[1] for t in cut_df.index]
+
+    # when
+    new_vals, new_ions = lfq_protint._cut_peptide_values(
+        df.to_numpy(), np.array(ion_names), maximum=3
+    )
+
+    # then - identical ion order and values
+    assert list(new_ions) == pc_ions
+    assert np.array_equal(new_vals, cut_df.to_numpy(), equal_nan=True)
+
+
+def test_cut_peptide_values_is_noop_within_limit():
+    ion_names = ["ion0", "ion1", "ion2"]
+    rows = [[1.0, 2.0], [3.0, np.nan], [5.0, 6.0]]
+    df = _make_ion_df(rows, ion_names)
+
+    cut_df = lfq_protint.ProtvalCutter(
+        df.copy(), maximum_df_length=100
+    ).get_dataframe()
+    pc_ions = [t[1] for t in cut_df.index]
+
+    new_vals, new_ions = lfq_protint._cut_peptide_values(
+        df.to_numpy(), np.array(ion_names), maximum=100
+    )
+
+    assert list(new_ions) == pc_ions == ion_names
+    assert np.array_equal(new_vals, cut_df.to_numpy(), equal_nan=True)
+
+
 def test_that_protein_intensities_are_retained():
     peptide1 = lfq_testutils.PeptideProfile(
         protein_name="protA",


### PR DESCRIPTION
supersedes: https://github.com/MannLabs/directlfq/pull/88
The individual commits should now be easier to understand.
All unit tests pass at every commit.

Original description:

Replaces the per-protein pandas interface with numpy on the hot path: the work producer yields array-slice tuples instead of building/pickling ~14k MultiIndex DataFrames; the worker computes on numpy and returns a 4-tuple. Adds numpy helpers _cut_peptide_values / _normalize_protein_values; ProtvalCutter / NormalizationManagerProtein retained for other callers. Includes the Fortran-order summed_pepint and lexsort tie-break fixes for bit-exactness.

Estimated speedup: estimate stage 16.2 s → 9.6 s single-core (~1.7×), and restores multi-core scaling (8-core estimate ~10.5 s → ~2.4 s).

Bit-identical protein + ion output (max_abs_diff=0); suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)