### PR TITLE
perf(mem): in-place nan_to_num for the ion table (A2)

### DIFF
--- a/directlfq/protein_intensity_estimation.py
+++ b/directlfq/protein_intensity_estimation.py
@@ -249,7 +249,7 @@ def get_ion_intensity_dataframe_from_list_of_shifted_peptides(
         ion_vals.append(shifted_values)
         protein_names.extend([protein_name] * len(ion_names_arr))
     merged_ions = 2 ** np.concatenate(ion_vals)
-    merged_ions = np.nan_to_num(merged_ions)
+    np.nan_to_num(merged_ions, copy=False)
     ion_df = pd.DataFrame(merged_ions)
     ion_df.columns = column_names
     ion_df["ion"] = ion_names

--- a/tests/pytest/test_protein_intensity_estimation.py
+++ b/tests/pytest/test_protein_intensity_estimation.py
@@ -1,7 +1,9 @@
 """Tests for directlfq.protein_intensity_estimation, salvaged from nbdev_nbs/03_protein_intensity_estimation.ipynb."""
 
 import numpy as np
+import pandas as pd
 import pytest
+from pandas.testing import assert_frame_equal
 
 import directlfq.protein_intensity_estimation as lfq_protint
 import directlfq.test_utils as lfq_testutils
@@ -268,3 +270,40 @@ def test_single_sample_values_are_kept_and_protein_retained():
     assert profile is not None
     assert name == "protA"
     assert list(ions) == ["ion0", "ion1", "ion2"]
+
+
+# ============================================================================
+# get_ion_intensity_dataframe_from_list_of_shifted_peptides (memory optim. A2)
+# ============================================================================
+# Contract locked in before switching the ion-table nan_to_num to in-place: each
+# per-protein (profile, name, ion_names, shifted_values) tuple contributes its
+# ions to one (protein, ion)-indexed frame; shifted log2 values are raised to
+# 2**x back into linear space and NaNs are replaced with 0.
+
+
+def test_ion_intensity_dataframe_delogs_values_and_zeroes_nans():
+    # given - two proteins; shifted values are in log2 space, one NaN per protein
+    tuples = [
+        (
+            None,
+            "protA",
+            np.array(["ion0", "ion1"]),
+            np.array([[1.0, 2.0], [3.0, np.nan]]),
+        ),
+        (None, "protB", np.array(["ion2"]), np.array([[0.0, np.nan]])),
+    ]
+
+    # when
+    result = lfq_protint.get_ion_intensity_dataframe_from_list_of_shifted_peptides(
+        tuples, column_names=["S1", "S2"]
+    )
+
+    # then - 2**x back to linear space, NaN -> 0, indexed by (protein, ion)
+    expected = pd.DataFrame(
+        {"S1": [2.0, 8.0, 1.0], "S2": [4.0, 0.0, 0.0]},
+        index=pd.MultiIndex.from_arrays(
+            [["protA", "protA", "protB"], ["ion0", "ion1", "ion2"]],
+            names=["protein", "ion"],
+        ),
+    )
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
## Step 2 of the memory-reduction plan (A2)

Stacked on top of #93 (A1b).

`get_ion_intensity_dataframe_from_list_of_shifted_peptides` replaced NaNs with `np.nan_to_num(merged_ions)`, which allocates a second full copy of the ion matrix. `merged_ions` is a freshly-allocated array (`2 ** np.concatenate(...)`), so it can be zeroed in place: `np.nan_to_num(merged_ions, copy=False)`.

### Correctness
- **Bit-exact**: same values, same NaN->0 mapping, only the copy is removed. Reference check reports `VERDICT identical=True`.
- New contract test (committed *before* the change) covers the de-log (`2**x`), NaN->0, and `(protein, ion)` indexing.
- Full pytest suite (46 tests) passes.

> Peak-PSS memory was not re-measured (Linux-only `/proc`); verification is correctness-only per agreement. On the plan's dataset this removes a ~57 MB transient with no change to the global peak — it mainly helps larger inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)