### PR TITLE
feat(mem): opt-in float32 intensity path (A3)

### DIFF
--- a/directlfq/config.py
+++ b/directlfq/config.py
@@ -1,4 +1,5 @@
 import logging
+import numpy as np
 import pandas as pd
 
 
@@ -33,6 +34,15 @@ def set_global_protein_and_ion_id(protein_id="protein", quant_id="ion"):
     global QUANT_ID
     PROTEIN_ID = protein_id
     QUANT_ID = quant_id
+
+
+##########################
+INTENSITY_DTYPE = np.float64
+
+
+def set_intensity_dtype(use_float32: bool = False) -> None:
+    global INTENSITY_DTYPE
+    INTENSITY_DTYPE = np.float32 if use_float32 else np.float64
 
 
 ##########################

--- a/directlfq/lfq_manager.py
+++ b/directlfq/lfq_manager.py
@@ -40,6 +40,7 @@ def run_lfq(
     protein_id="protein",
     quant_id="ion",
     compile_normalized_ion_table=True,
+    use_float32=False,
 ):
     """Run the directLFQ pipeline on a given input file. The input file is expected to contain ion intensities. The output is a table containing protein intensities.
 
@@ -59,6 +60,7 @@ def run_lfq(
     config.set_compile_normalized_ion_table(
         compile_normalized_ion_table=compile_normalized_ion_table
     )
+    config.set_intensity_dtype(use_float32=use_float32)
     config.check_wether_to_copy_numpy_arrays_derived_from_pandas()
 
     LOGGER.info("Starting directLFQ analysis.")

--- a/directlfq/utils.py
+++ b/directlfq/utils.py
@@ -353,7 +353,7 @@ def write_chunk_to_file(chunk, filepath, write_header):
 
 def index_and_log_transform_input_df(data_df):
     data_df = data_df.set_index([config.PROTEIN_ID, config.QUANT_ID])
-    values = data_df.to_numpy(dtype=np.float64, copy=True)
+    values = data_df.to_numpy(dtype=config.INTENSITY_DTYPE, copy=True)
     values[values == 0] = np.nan
     np.log2(values, out=values)
     return pd.DataFrame(values, index=data_df.index, columns=data_df.columns)

--- a/tests/pytest/test_config.py
+++ b/tests/pytest/test_config.py
@@ -1,0 +1,40 @@
+"""Tests for directlfq.config."""
+
+import numpy as np
+import pytest
+
+import directlfq.config as config
+
+
+# ============================================================================
+# set_intensity_dtype (memory optimization A3)
+# ============================================================================
+# The opt-in float32 path flips a single module-global that every downstream
+# intensity matrix inherits. Default must stay float64 to keep the bit-exact path.
+
+
+@pytest.fixture(autouse=True)
+def _restore_intensity_dtype():
+    original = config.INTENSITY_DTYPE
+    yield
+    config.INTENSITY_DTYPE = original
+
+
+def test_set_intensity_dtype_defaults_to_float64():
+    config.set_intensity_dtype()
+
+    assert config.INTENSITY_DTYPE == np.float64
+
+
+def test_set_intensity_dtype_true_selects_float32():
+    config.set_intensity_dtype(use_float32=True)
+
+    assert config.INTENSITY_DTYPE == np.float32
+
+
+def test_set_intensity_dtype_false_selects_float64():
+    config.set_intensity_dtype(use_float32=True)
+
+    config.set_intensity_dtype(use_float32=False)
+
+    assert config.INTENSITY_DTYPE == np.float64

--- a/tests/pytest/test_lfq_manager.py
+++ b/tests/pytest/test_lfq_manager.py
@@ -1,0 +1,37 @@
+"""Tests for directlfq.lfq_manager."""
+
+from unittest.mock import patch
+
+import pytest
+
+import directlfq.lfq_manager as lfq_manager
+
+
+# ============================================================================
+# run_lfq use_float32 wiring (memory optimization A3)
+# ============================================================================
+# run_lfq must forward its use_float32 flag to config.set_intensity_dtype so the
+# opt-in path takes effect. import_data is stubbed to stop the pipeline right
+# after the config block, keeping the test independent of any input file.
+
+
+class _StopPipeline(Exception):
+    """Sentinel raised to abort run_lfq once the config block has executed."""
+
+
+@patch("directlfq.lfq_manager.lfqutils.import_data", side_effect=_StopPipeline)
+@patch("directlfq.lfq_manager.config.set_intensity_dtype")
+def test_run_lfq_forwards_use_float32_true(mock_set_dtype, mock_import):  # noqa: ARG001
+    with pytest.raises(_StopPipeline):
+        lfq_manager.run_lfq("dummy_input.tsv", use_float32=True)
+
+    mock_set_dtype.assert_called_once_with(use_float32=True)
+
+
+@patch("directlfq.lfq_manager.lfqutils.import_data", side_effect=_StopPipeline)
+@patch("directlfq.lfq_manager.config.set_intensity_dtype")
+def test_run_lfq_defaults_use_float32_to_false(mock_set_dtype, mock_import):  # noqa: ARG001
+    with pytest.raises(_StopPipeline):
+        lfq_manager.run_lfq("dummy_input.tsv")
+
+    mock_set_dtype.assert_called_once_with(use_float32=False)

--- a/tests/pytest/test_utils.py
+++ b/tests/pytest/test_utils.py
@@ -2,10 +2,18 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 from pandas.testing import assert_frame_equal
 
 import directlfq.config as config
 import directlfq.utils as lfqutils
+
+
+@pytest.fixture
+def _restore_intensity_dtype():
+    original = config.INTENSITY_DTYPE
+    yield
+    config.INTENSITY_DTYPE = original
 
 
 # ============================================================================
@@ -74,3 +82,22 @@ def test_index_and_log_transform_does_not_mutate_input_df():
 
     # then - the caller's frame is untouched
     assert_frame_equal(df, df_before)
+
+
+def test_index_and_log_transform_follows_config_intensity_dtype(
+    _restore_intensity_dtype,
+):  # noqa: ARG001
+    # given - the opt-in float32 dtype is selected
+    df = _wide_input_df({"S1": [1.0, 4.0, 2.0], "S2": [8.0, 16.0, 32.0]})
+    config.INTENSITY_DTYPE = np.float32
+
+    # when
+    result = lfqutils.index_and_log_transform_input_df(df)
+
+    # then - output is float32 and stays close to the float64 log2 values
+    assert all(result.dtypes == np.float32)
+    config.INTENSITY_DTYPE = np.float64
+    expected_float64 = lfqutils.index_and_log_transform_input_df(df)
+    assert np.allclose(
+        result.to_numpy(), expected_float64.to_numpy(), rtol=1e-6, equal_nan=True
+    )


### PR DESCRIPTION
## Step 3 of the memory-reduction plan (A3)

Stacked on top of #94 (A2). Adds an **opt-in** float32 intensity path that halves every large matrix. Default stays float64 and bit-exact.

### Changes
- **A3a** `config.INTENSITY_DTYPE` + `set_intensity_dtype(use_float32=False)` — one module-global everything downstream inherits.
- **A3b** `index_and_log_transform_input_df` casts to `config.INTENSITY_DTYPE` at the single existing cast point (from #93). float32 then flows through normalization, per-protein slices, and the ion table with no other edits.
- **A3c** `run_lfq(..., use_float32=False)` forwards the flag to `config.set_intensity_dtype`.

### Correctness
- **Default (float64) bit-exact**: `convert`-free path, `INTENSITY_DTYPE` defaults to float64. `benchmark_/optbench.py` -> `VERDICT identical=True`.
- **float32 accuracy** (real HYE dataset, vs the float64 reference): NaN pattern identical, **max relative error 5.07e-6** (protein 3.64e-6, ion 5.07e-6) — matches the plan's ~6e-6 expectation.
- New tests: `test_config.py` (dtype flag), `test_utils.py` (dtype propagation + float32 stays close to float64), `test_lfq_manager.py` (run_lfq forwards the flag). Full suite: 52 tests pass.

### Caveat (documented in the plan)
Leaving log space for the intensity-conserving sum reductions accumulates a float32 sum over values spanning many orders of magnitude, which loses the smallest terms. Measured impact stays at ~5e-6 relative here; float32 is opt-in precisely because it is not bit-exact.

> Note: A1a and A4 from the plan were **skipped** — they target a pyarrow `_read_wide_tsv` read path that does not exist in this repo (the wide table is read via plain `pd.read_csv`). Peak-PSS memory is Linux-only and was not re-measured on macOS; verification is correctness-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)